### PR TITLE
Add ^8.0 to list of supported php versions (Fixes #1)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^5.6 || ^7.0"
+        "php": "^5.6 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi! I made this patch to add PHP8 to the list of supported versions :)

It's related to the issue I opened some days ago. If this is merged is there a chance to make a new release in packagist?

Thanks!!